### PR TITLE
enable windows CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "10"
 os:
-  # - windows # TODO: make this work
+  - windows
   - linux
 cache:
-  yarn: true
+  yarn: false


### PR DESCRIPTION
```
The command "yarn test" exited with 0.
cache.2
store build cache
2.81sRunning casher in bash
changes detected (content changed, file is created, or file is deleted):
C:\Users	ravis\AppData\Local\Yarn\Cache4
pm-@types-tmp-0.0.33-1073c4bc824754ae3d10cfab88ab0237ba964e4d
ode_modules\@types	mp\.yarn-metadata.json
C:\Users	ravis\AppData\Local\Yarn\Cache4
pm-@types-tmp-0.0.33-1073c4bc824754ae3d10cfab88ab0237ba964e4d
ode_modules\@types	mp\.yarn-tarball.tgz
C:\Users	ravis\AppData\Local\Yarn\Cache4
pm-@types-tmp-0.0.33-1073c4bc824754ae3d10cfab88ab0237ba964e4d
ode_modules\@types	mp\LICENSE
C:\Users	ravis\AppData\Local\Yarn\Cache4
pm-@types-tmp-0.0.33-1073c4bc824754ae3d10cfab88ab0237ba964e4d
ode_modules\@types	mp\README.md
C:\Users	ravis\AppData\Local\Yarn\Cache4
pm-@types-tmp-0.0.33-1073c4bc824754ae3d10cfab88ab0237ba964e4d
ode_modules\@types	mp\index.d.ts
C:\Users	ravis\AppData\Local\Yarn\Cache4
pm-@types-tmp-0.0.33-1073c4bc824754ae3d10cfab88ab0237ba964e4d
ode_modules\@types	mp\package.json
C:\Users	ravis\AppData\Local\Yarn\Cache4
pm-ajv-6.9.1-a4d3683d74abc5670e75f0b16520f70a20ea8dc1
ode_modulesjv\.tonic_example.js
...
changes detected, packing new archive
uploading PR.1/cache-windows-1803-containers-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855--node-10.tgz
cache uploaded
Done. Your build exited with 0.
tar: C\:\\Users\travis\\AppData\\Local\\Yarn\\Cache: Cannot stat: No such file or directory
tar: Exiting with failure status due to previous errors
```